### PR TITLE
Add xAI Grok models

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,17 @@ The dates come from official technical reports, API providers, GitHub issues, an
 | --- | --- | --- | --- |
 | Phi-3-* | Microsoft | 2023.10 | [Source](https://console.cloud.google.com/vertex-ai/publishers/microsoft/model-garden/phi3?pli=1) |
 
+# xAI Models
+| Model Name | Company | Cut-off Date | Source |
+| --- | --- | --- | --- |
+| Grok 2 | xAI | 2023.09 | [Source](https://aimlapi.com/models/grok-2-beta-api) |
+| Grok 3 | xAI | 2024.11 | [Source](https://docs.x.ai/docs/models) |
+| Grok 4 | xAI | 2024.11 | [Source](https://docs.x.ai/docs/models) |
 
 # Unknown Models
 | Model Name | Company | Cut-off Date | Source |
 | --- | --- | --- | --- |
 | Mistral series            | Mistral AI| unknown       |                                                                                                                           |
-| Grok-*                    | xAI       | unknown       |   
 
 
 ## Star History


### PR DESCRIPTION
xAI is not overly transparent with their model cut-off dates, but it appeared the cut-off date of Grok 3 and 4 is hidden in a note on the mentioned page. Grok 2 is not officially confirmed by xAI, but I think the provided link is relevant enough. Removed xAI Grok from the "unkown models" table.