### PR TITLE
Update DeepSeek-R1 cutoff date to 2024.07

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # LLM Knowledge Cut-off Dates Summary
-This repository contains a summary of knowledge cut-off dates for various large language models (LLMs), including models such as GPT, Claude, Gemini, Llama, and more. 
+This repository contains a summary of knowledge cut-off dates for various large language models (LLMs), including models such as GPT, Claude, Gemini, Llama, and more.
 
 ### Source
 The dates come from official technical reports, API providers, GitHub issues, and other public resources. Please feel free to add or update any details regarding the knowledge cut-off dates for any model.
 
 # News
 * [2025.12] Update more models! Contributions backed by trustworthy and verifiable sources are highly appreciated!
-* [2025.6] More SOTA models are added! We welcome your contributions to keep this list updated!! 
+* [2025.6] More SOTA models are added! We welcome your contributions to keep this list updated!!
 
 
 # OpenAI
@@ -45,7 +45,7 @@ The dates come from official technical reports, API providers, GitHub issues, an
 | GPT-5.2 Instant, Thinking, Pro | OpenAI | 2025.08 | [Source](https://platform.openai.com/docs/guides/latest-model) |
 
 
-# Google 
+# Google
 | Model Name | Company | Cut-off | Source |
 | :---:  | :---:  | :---:  | :---:  |
 | Gemini 1.0 Pro | Google | 2023.02 | [Source](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models) |
@@ -53,7 +53,7 @@ The dates come from official technical reports, API providers, GitHub issues, an
 | Gemini 1.5 Flash | Google | 2024.05 | [Source](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models) |
 | Gemini 2.0 Flash | Google | 2024.08 | [Source](https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash) |
 | Gemini 2.0 Flash Thinking | Google | 2024.05 | [Source](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models) |
-| Gemini 2.0 Flash-Lite | Google | 2024.08 | [Source](https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash-lite) | 
+| Gemini 2.0 Flash-Lite | Google | 2024.08 | [Source](https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash-lite) |
 | Gemini 2.0 Pro Experimental | Google | 2025.01 | [Source](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models) |
 | Gemini 2.5 Flash-Lite | Google | 2025.01 | [Source](https://ai.google.dev/gemini-api/docs/models?hl=zh-cn#gemini-2.5-flash-lite) |
 | Gemini 2.5 Flash | Google | 2025.01 | [Source](https://deepmind.google/models/gemini/flash/) |
@@ -81,7 +81,7 @@ The dates come from official technical reports, API providers, GitHub issues, an
 | Claude 4.5 Opus | Anthropic | 2025.08 | 2025.05 | [Source](https://web.archive.org/web/20251217180521/https://platform.claude.com/docs/en/about-claude/models/overview#latest-models-comparison) |
 > **Note:** In Claude’s official documentation, “knowledge cut-off” is split into **Reliable knowledge cut-off** and **Training data cut-off**. Reliable knowledge cutoff indicates the date through which a model’s knowledge is most extensive and reliable, while training data cutoff reflects the broader date range of training data used. Therefore, we added the **Reliable Knowledge Cut-off Date** column to align this table with the official definitions. [Reference](https://web.archive.org/web/20251217180521/https://platform.claude.com/docs/en/about-claude/models/overview#latest-models-comparison)
 
-# Meta 
+# Meta
 | Model Name | Company | Cut-off | Source |
 | :-------:  | :----:  | :----:  | :---:  |
 | LLama-2-7B,13B,70B | Meta | Pretraining 2022.09, Finetuning  2023.07 | [Source](https://llama-2.ai/llama-2-model-details/) |
@@ -96,7 +96,7 @@ The dates come from official technical reports, API providers, GitHub issues, an
 | Llama-4-Maverick (17Bx128E) | Meta | 2024.08 | [Source](https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct) |
 
 
-# Qwen 
+# Qwen
 | Model Name | Company | Cut-off | Source |
 | :-------:  | :---:  | :---:  | :---:  |
 | Qwen2-7B-Instruct | Qwen | 2023 | [Source](https://docs.rubra.ai/models/Qwen/) |
@@ -104,21 +104,21 @@ The dates come from official technical reports, API providers, GitHub issues, an
 | QwQ-32B | Qwen | 2024.11.28 | [Source](https://llm-stats.com/models/compare/qwen3-30b-a3b-vs-qwq-32b) |
 | Qwen3 | Qwen | Unknown | TBD  |
 
-# DeepSeek 
+# DeepSeek
 | Model Name | Company | Cut-off  | Source |
 | :-------:  | :---:  | :---:  | :---:  |
 | DeepSeek-LLM-7B/67B-Chat | DeepSeek | 2023.05 | [Source](https://arxiv.org/pdf/2401.02954v1) |
 | DeepSeek-Coder | DeepSeek | 2023.03 | [Source](https://github.com/deepseek-ai/DeepSeek-Coder/issues/89) |
 | DeepSeek-Coder-V2         | DeepSeek  | 2023.11       | [Source](https://github.com/deepseek-ai/DeepSeek-Coder-V2/issues/1)                                                       |
 | DeepSeek-V3 | DeepSeek | 2024.07 | [Source](https://explodingtopics.com/blog/list-of-llms)
-| DeepSeek-R1 | DeepSeek | 2025.01 | [Source](https://explodingtopics.com/blog/list-of-llms)
+| DeepSeek-R1 | DeepSeek | 2024.07 | [Source](https://explodingtopics.com/blog/list-of-llms)
 
-# Microsoft 
+# Microsoft
 | Model Name | Company | Cut-off | Source |
 | :-------:  | :---:  | :---:  | :---:  |
 | Phi-3-* | Microsoft | 2023.10 | [Source](https://console.cloud.google.com/vertex-ai/publishers/microsoft/model-garden/phi3?pli=1) |
 
-# xAI 
+# xAI
 | Model Name | Company | Cut-off | Source |
 | :-------:  | :---:  | :---:  | :---:  |
 | Grok 2 | xAI | 2023.09 | [Source](https://aimlapi.com/models/grok-2-beta-api) |


### PR DESCRIPTION
The source says the cutoff date is 2024.07. I also checked the paper for DeepSeek-R1, which said the model was based on DeepSeek-V3, whose cutoff date was 2024.07.

The PR also fixes the trailing whitespaces.

