### PR TITLE
Added GPT-5.3 and GPT-5.4 cutoff dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ A curated summary of knowledge cut-off dates for various large language models (
 | GPT-5 nano | OpenAI | 2024.05.31 | [Source](https://web.archive.org/web/20260131125420/https://platform.openai.com/docs/models/gpt-5-nano) |
 | GPT-5.1 | OpenAI | 2024.09.30 | [Source](https://web.archive.org/web/20260131021842/https://platform.openai.com/docs/models/gpt-5.1) |
 | GPT-5.2 Instant, Thinking, Pro | OpenAI | 2025.08 | [Source](https://web.archive.org/web/20260209181732/https://platform.openai.com/docs/guides/latest-model) |
+| GPT-5.3 Chat, Codex | OpenAI | 2025.08 | [Source](https://developers.openai.com/api/docs/models/gpt-5.3-codex) |
+| GPT-5.4 Pro, Nano, Mini | OpenAI | 2025.08 | [Source](https://developers.openai.com/api/docs/models/gpt-5.4) |
+
 
 ## Google
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ A curated summary of knowledge cut-off dates for various large language models (
 | GPT-5 nano | OpenAI | 2024.05.31 | [Source](https://web.archive.org/web/20260131125420/https://platform.openai.com/docs/models/gpt-5-nano) |
 | GPT-5.1 | OpenAI | 2024.09.30 | [Source](https://web.archive.org/web/20260131021842/https://platform.openai.com/docs/models/gpt-5.1) |
 | GPT-5.2 Instant, Thinking, Pro | OpenAI | 2025.08 | [Source](https://web.archive.org/web/20260209181732/https://platform.openai.com/docs/guides/latest-model) |
-| GPT-5.3 Chat, Codex | OpenAI | 2025.08 | [Source](https://developers.openai.com/api/docs/models/gpt-5.3-codex) |
-| GPT-5.4 Pro, Nano, Mini | OpenAI | 2025.08 | [Source](https://developers.openai.com/api/docs/models/gpt-5.4) |
+| GPT-5.3 Chat, Codex | OpenAI | 2025.08 | [Source](https://web.archive.org/web/20260317134442/https://developers.openai.com/api/docs/models/gpt-5.3-codex) |
+| GPT-5.4 Pro, Nano, Mini | OpenAI | 2025.08 | [Source](https://web.archive.org/web/20260318054837/https://developers.openai.com/api/docs/models/gpt-5.4) |
 
 
 ## Google


### PR DESCRIPTION
This pull request updates the `README.md` file to include the latest knowledge cut-off dates for new OpenAI models. Two new models, GPT-5.3 and GPT-5.4, have been added to the summary table.

Additions to the knowledge cut-off summary:

* Added `GPT-5.3 Chat, Codex` (OpenAI, 2025.08) with a source link to the official documentation.
* Added `GPT-5.4 Pro, Nano, Mini` (OpenAI, 2025.08) with a source link to the official documentation.